### PR TITLE
Tidy spaces in Het-SBM.R

### DIFF
--- a/Het-SBM.R
+++ b/Het-SBM.R
@@ -20,13 +20,6 @@ Het-SBM <- function(X,D,qmin,qmax, t_max = 10, h_max = 10,threshold_h = 10^-10,
       print(paste("Model_Q = ",Q))
       while(t <= t_max & delta_psi > threshold_psi){
         print(paste("t_iteration=",t))
-          # require(stats)
-          # X_all<-apply(X,c(1,2),sum)
-          # Z_all<-kmeans(X_all,Q,30,30)$cluster
-          # tau<-matrix(tau_min,n,Q)	
-          # for(q in 1:Q){				#Tau zero
-          # 	tau[Z_all==q,q]<-1-(Q-1)* tau_min
-          # }
         if(t == 1){
           X_all = apply(X,c(1,2),function(x)sum(x))      # Sum data over subjects
           if(startType == "KMeans"){
@@ -128,20 +121,6 @@ Het-SBM <- function(X,D,qmin,qmax, t_max = 10, h_max = 10,threshold_h = 10^-10,
           while(h <= h_max & delta_h > threshold_h){
             tau_previous =  tau	 					
             for(i in 1:n){
-              # tmp <- log(Alpha)
-              # for (k in 1:K){
-              #   for (l in 1:Q){									
-              #     tmp1 <- tcrossprod(D[k,],beta[,l,])
-              #     tmp2 <- sum(tau[X[i,,k]==1,l]) * tmp1 - sum(tau[-i,l]) * log(1+exp(tmp1))  
-              #     # if (any(l== monoBlock)) tmp2 [l] <- 0
-              #     tmp <- tmp + tmp2
-              #   }
-              # }
-              # posTerm <- apply(tmp1, 3, function(x){ a <- tcrossprod(tau, x); return(sum(a[X[i,,]==1])) })
-              # negTerm <- apply(logOnePlusExpTmp1, 3, function(x) sum(tcrossprod(tau[-i,], x)))
-              
-              # tau[i,]=tau[i,]/(sum(tau[i,]))   		      # normalising after eq. 10 
-              
               posTerm                       = crossprod(as.numeric(tau), Xtmp1[i,,])
               negTerm                       = tcrossprod(colSums(tau[-i,]), sumLogOnePlusExpTmp1)
               tmp                           = log(Alpha) + posTerm - negTerm
@@ -225,15 +204,10 @@ Het-SBM <- function(X,D,qmin,qmax, t_max = 10, h_max = 10,threshold_h = 10^-10,
             gamma = tcrossprod(tau[,q],tau[,l])
             gamma = gamma + t(gamma)    
           }
-          # if (q==l & any(l== monoBlock)){
-          #   
-          # } else {
-          # }					
             tmp1 =  D %*% beta[q,l,]			
             Qlik =  Qlik + crossprod(apply(X,3, function(x) sum(gamma[x==1])), tmp1) - (sum(gamma)-sum(diag(gamma))) * sum(log(1+exp(tmp1)))
         }
       }
-        # warning(paste("Failed to converge to Model with ",Q," groups",sep=""))
       Qlik    = 0.5*Qlik
       ICL     = Qlik - P*Q*(Q+1)/4*log(K*n*(n-1)/2) - (Q-1)/2*log(n)
       part    = apply(tau,1,function(x)which.max(x))

--- a/Het-SBM.R
+++ b/Het-SBM.R
@@ -1,6 +1,8 @@
-Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=10^-10, threshold_lik=10^-10,
-                      M_iter=10,threshold_psi=10^-10,startType="KMeans",kmeanType = "correlation",kmeanMax=30,startZ=NULL,iSubjStartingPoint = NULL,method="Firth"){
-  
+Het-SBM <- function(X,D,qmin,qmax, t_max = 10, h_max = 10,threshold_h = 10^-10,
+                     tau_min = 10^-10, threshold_lik = 10^-10, M_iter = 10,
+                     threshold_psi = 10^-10, startType = "KMeans",
+                     kmeanType = "correlation", kmeanMax = 30,startZ = NULL,
+                     iSubjStartingPoint = NULL, method = "Firth"){
   n   = dim(X)[1]  # Number of nodes
   K   = dim(X)[3]  # Number of subjects
   P   = dim(D)[2]  # Number of covariates

--- a/Het-SBM.R
+++ b/Het-SBM.R
@@ -1,16 +1,16 @@
 Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=10^-10, threshold_lik=10^-10,
                       M_iter=10,threshold_psi=10^-10,startType="KMeans",kmeanType = "correlation",kmeanMax=30,startZ=NULL,iSubjStartingPoint = NULL,method="Firth"){
   
-  n<-dim(X)[1]
-  K<-dim(X)[3]
-  P<-dim(D)[2]
+  n   = dim(X)[1]  # Number of nodes
+  K   = dim(X)[3]  # Number of subjects
+  P   = dim(D)[2]  # Number of covariates
   # h is concerened with update of tau
   # t is concerened with maximisation of all other parameters
-  rezultat <- list()
+  rezultat =  list()
   for(Q in qmin:qmax){
     convergence = FALSE
     fail_rate = 0
-    varBound <- numeric(t_max)
+    varBound     = numeric(t_max)
     while (!convergence & fail_rate < 1 ){	
       # Initialize tau or update tau
       t <- 1
@@ -44,7 +44,7 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
             }
           }
           if(startType=="StartingPoint"){
-            Z_all <- startZ[[Q]]
+            Z_all =  startZ[[Q]]
           }
           if(startType=="Random"){
             #######################################################################
@@ -52,11 +52,11 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
             #######################################################################
             attempts2=0
             while(attempts2<11){
-              Z_all<-sample(1:Q,n,replace=TRUE)
+              Z_all = sample(1:Q,n,replace=TRUE)
               Z_nqs = as.data.frame(table(Z_all))$Freq
               if(any(Z_nqs<3)){
                 attempts2 = attempts2 + 1
-                Z_all <- sample(1:Q,n,replace=TRUE)        	      
+                Z_all     = sample(1:Q,n,replace=TRUE)        	      
               }else{
                 break()
               }
@@ -99,33 +99,32 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
             Z_all=cutree(tmp,k=Q)
           }
           # Build tau using the first guess of Z
-          tau<-matrix(tau_min,n,Q)              #populate tau with minimum values we cannot deal with zero
+          tau = matrix(tau_min,n,Q)              #populate tau with minimum values we cannot deal with zero
           for(q in 1:Q){
-            tau[Z_all==q,q]<-1-(Q-1)*tau_min    #normalise tau
+            tau[Z_all==q,q] = 1-(Q-1)*tau_min    #normalise tau
           }
         }
         else{ # for all t that are >=2 we eneter to optimise tau
-          h <- 1
-          delta_h <- 1
-          monoBlock <- which(sapply(1:Q, function(x) length(which(apply(tau, 1, which.max)==x))) == 1) # Check for the monoblock
+          h          = 1
+          delta_h    = 1
+          monoBlock  = which(sapply(1:Q, function(x) length(which(apply(tau, 1, which.max)==x))) == 1) # Check for a block with one node
           
           # do stuff not affected by upadtes of tau
-          tmp1 <- array(0, dim = c(K, Q, Q))
+          tmp1 = array(0, dim = c(K, Q, Q))
           for (l in 1:Q){									
-            tmp1[,,l] <- tcrossprod(D,beta[,l,])
+            tmp1[,,l]  =  tcrossprod(D,beta[,l,])
           }
           # logOnePlusExpTmp1 <- log(1+exp(tmp1))  
-          sumLogOnePlusExpTmp1 <- apply(log(1+exp(tmp1)), 2:3, sum)
-
-          Xtmp1 <- array(0, dim = c(n,n*Q,Q))
+          sumLogOnePlusExpTmp1 = apply(log(1+exp(tmp1)), 2:3, sum)
+          Xtmp1                = array(0, dim = c(n,n*Q,Q))
           for(i in 1:n){
             for(q in 1:Q){
-              Xtmp1[i,,q] <- as.numeric(X[i,,] %*% tmp1[,,q])
+              Xtmp1[i,,q] =  as.numeric(X[i,,] %*% tmp1[,,q])
             }
           }          
           
           while(h<=h_max & delta_h>threshold_h){ # Here we update tau
-            tau_previous<-tau	 					
+            tau_previous =  tau	 					
             for(i in 1:n){
               # tmp <- log(Alpha)
               # for (k in 1:K){
@@ -137,62 +136,66 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
               #   }
               # }
               # posTerm <- apply(tmp1, 3, function(x){ a <- tcrossprod(tau, x); return(sum(a[X[i,,]==1])) })
-              posTerm <- crossprod(as.numeric(tau), Xtmp1[i,,])
               # negTerm <- apply(logOnePlusExpTmp1, 3, function(x) sum(tcrossprod(tau[-i,], x)))
-              negTerm <- tcrossprod(colSums(tau[-i,]), sumLogOnePlusExpTmp1)
-              tmp <- log(Alpha) + posTerm - negTerm
               
               tau[i,]=1/colSums(exp(outer(as.numeric(tmp), as.numeric(tmp),FUN="-")))
               # tau[i,]=tau[i,]/(sum(tau[i,]))   		      # normalising after eq. 10 
-              tau[i,tau[i,]< tau_min]<-tau_min            # smaller than smallest is set to our view of small :)
-              tau[i,which.max(tau[i,])[1]]<-(1-sum(tau[i,-which.max(tau[i,])[1]])) # to keep normalization in check!
               
+              posTerm                       = crossprod(as.numeric(tau), Xtmp1[i,,])
+              negTerm                       = tcrossprod(colSums(tau[-i,]), sumLogOnePlusExpTmp1)
+              tmp                           = log(Alpha) + posTerm - negTerm
+              tau[i,tau[i,]< tau_min]       = tau_min                                 # smaller than smallest is set to our view of small :)
+              tau[i,which.max(tau[i,])[1]]  = (1-sum(tau[i,-which.max(tau[i,])[1]]))  # to keep normalization in check!
             }
-            delta_h<-max(abs(tau-tau_previous)/tau_previous)   # fixed delta and new delta, we take a maximum 
+            delta_h      = max(abs(tau-tau_previous)/tau_previous)   
             # print(delta_h)
             h=h+1	
           }# Here we update tau					
         }# for all t that are >=2 we eneter to optimised tau
-        monoBlock <- which(sapply(1:Q, function(x) length(which(apply(tau, 1, which.max)==x))) == 1) # Check for the monoblock
-        if(t>1)Alpha_previous <- Alpha
-        Alpha<-apply(tau,2,sum)/n
+        monoBlock =  which(sapply(1:Q, function(x) length(which(apply(tau, 1, which.max)==x))) == 1) # Check for the monoblock
+        if(t > 1) {
+          Alpha_previous =  Alpha
+        }  
+        Alpha     =  apply(tau,2,sum)/n
         # print(Alpha)
         if (t==1){
-          Emp_Pis<-matrix(0,Q,Q)  # this is just our estimate of intercept
+          Emp_Pis = matrix(0,Q,Q)  # Emp_Pis are initail guess for intercept. 
           for(q in 1:Q){
             for(l in q:Q){
-              privr1<-as.matrix(X_all[Z_all==q,Z_all==l])
               if(q==l){
+              privr1 = as.matrix(X_all[Z_all==q,Z_all==l])
                 if(dim(privr1)[1]==1){
                   Emp_Pis[q,l]=sum(X_all[Z_all==q,])/(K*(n-1))
                 }
                 else{
-                  Emp_Pis[q,l]<-sum(privr1)/(K*dim(privr1)[1]*(dim(privr1)[2]-1))	
+                  Emp_Pis[q,l] = sum(privr1)/(K*dim(privr1)[1]*(dim(privr1)[2]-1))	
                 }
               }
               else{
-                Emp_Pis[q,l]<-sum(privr1)/(K*dim(privr1)[1]*dim(privr1)[2])
+                Emp_Pis[q,l]   =  sum(privr1)/(K*dim(privr1)[1]*dim(privr1)[2])
               }
             }
           }
-          Emp_Pis[Emp_Pis==1] <- 0.9
-          beta <- array(0,dim=c(Q,Q,P))
-          beta_init <- matrix(0,Q,Q)
           beta_init[upper.tri(Emp_Pis,diag=TRUE)]=log(Emp_Pis[upper.tri(Emp_Pis,diag=TRUE)]/(1-Emp_Pis[upper.tri(Emp_Pis,diag=TRUE)]))
-          beta_init[beta_init==-Inf]<-0
-          beta[,,1]<-beta_init
+          Emp_Pis[Emp_Pis == 1]                     =  0.9
+          beta                                      =  array(0,dim=c(Q,Q,P))
+          beta_init                                 =  matrix(0,Q,Q)
+          beta_init[beta_init == -Inf]                = 0
+          beta[,,1]                                 = beta_init
         }
         beta_previous <- beta
         if(method=="Firth"){
-          tmp<-firth_bs(beta, tau, D,X,threshold_lik=10^-10,M_iter=10,maxstep=5,half_iter=5) 
+          tmp   = firth_bs(beta, tau, D,X,threshold_lik=10^-10,M_iter=10,maxstep=5,half_iter=5) 
         }
         if(method=="MLE"){
-          tmp<-no_firth_bs(beta, tau, D,X,threshold_lik=10^-10,M_iter=10,maxstep=5,half_iter=5)
+          tmp   = no_firth_bs(beta, tau, D,X,threshold_lik=10^-10,M_iter=10,maxstep=5,half_iter=5)
         }
-        beta<-tmp$beta
-        FI<-tmp$FI
-        if (t>1) delta_psi<-max(abs((Alpha-Alpha_previous)/Alpha_previous),abs((beta-beta_previous)/beta_previous),na.rm = TRUE)
-        varBound[t] <- sum(tau%*%log(Alpha))-sum(tau*log(tau))
+        beta = tmp$beta
+        FI   = tmp$FI
+        if (t>1) {
+          delta_psi  =  max(abs((Alpha-Alpha_previous)/Alpha_previous),abs((beta-beta_previous)/beta_previous), na.rm = TRUE)
+        }  
+        varBound[t]  =  sum(tau%*%log(Alpha))-sum(tau*log(tau))
         for (q in 1:Q){
           for (l in q:Q){
             if(q==l){
@@ -204,14 +207,14 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
             # if (q==l & any(l== monoBlock)){
             #   
             # } else {
-              tmp1 <- D%*%beta[q,l,]			
+              tmp1        =  D%*%beta[q,l,]			
               varBound[t] = varBound[t] + 0.5*(crossprod(apply(X,3, function(x) sum(gamma[x==1])), tmp1) - (sum(gamma)-sum(diag(gamma))) * sum(log(1+exp(tmp1))))
             # }					
           }
         }
-        t <- t +1
+        t =  t +1
       }#end of while loop for t
-      Qlik<-2 * sum(tau%*%log(Alpha))
+      Qlik = 2 * sum(tau%*%log(Alpha))
       for (q in 1:Q){
         for (l in q:Q){
           if(q==l){
@@ -223,17 +226,17 @@ Het-SBM<-function(X,D,qmin,qmax, t_max=10, h_max=10,threshold_h=10^-10,tau_min=1
           # if (q==l & any(l== monoBlock)){
           #   
           # } else {
-            tmp1 <- D%*%beta[q,l,]			
             Qlik = Qlik + crossprod(apply(X,3, function(x) sum(gamma[x==1])), tmp1) - (sum(gamma)-sum(diag(gamma))) * sum(log(1+exp(tmp1)))
           # }					
+            tmp1 =  D %*% beta[q,l,]			
         }
       }
       Qlik=0.5*Qlik
-      ICL <- Qlik-P*Q*(Q+1)/4*log(K*n*(n-1)/2)-(Q-1)/2*log(n)
       part = apply(tau,1,function(x)which.max(x))
       part_sz=sapply(1:Q,function(x)sum(part==x))
       if(any(part_sz<1)){
         # warning(paste("Failed to converge to Model with ",Q," groups",sep=""))
+      ICL     = Qlik - P*Q*(Q+1)/4*log(K*n*(n-1)/2) - (Q-1)/2*log(n)
         fail_rate = fail_rate + 1
       }else{
         convergence = TRUE

--- a/Het-SBM.R
+++ b/Het-SBM.R
@@ -82,16 +82,16 @@ Het-SBM <- function(X,D,qmin,qmax, t_max = 10, h_max = 10,threshold_h = 10^-10,
             #      Initialise Z, using Hieararchical Clustering algorithm         #
             #######################################################################
             if (is.null(iSubjStartingPoint)){
-              X_all_d=dist(X_all,method="manhattan")
+              X_all_d = stats::dist(X_all,method="manhattan")
             } else {
               if (length(iSubjStartingPoint) == 1) {
-                X_all_d=dist(X[,,iSubjStartingPoint],method="manhattan")
+                X_all_d = stats::dist(X[,,iSubjStartingPoint],method="manhattan")
               } else {
-                X_all_d=dist(apply(X[,,iSubjStartingPoint],c(1,2),function(x)sum(x)),method="manhattan")
+                X_all_d = stats::dist(apply(X[,,iSubjStartingPoint],c(1,2),function(x)sum(x)),method="manhattan")
               }
             }
-            tmp=hclust(X_all_d,method="ward.D2")
-            Z_all=cutree(tmp,k=Q)
+            tmp   = stats::hclust(X_all_d, method ="ward.D2")
+            Z_all = stats::cutree(tmp, k = Q)
           }
           # Build tau using the first guess of Z
           tau = matrix(tau_min,n,Q)              #populate tau with minimum values we cannot deal with zero


### PR DESCRIPTION
The goals of this PR is:

- to tidy the function Het-SBM.R by using the same spacing convention everywhere
- to remove commented pieces of code that serve no purpose
- to use consistently the assignment symbol '=' instead of '<-'
- to format the function inputs
- to add namespace stats to some functions rather than call the whole library repeatedly